### PR TITLE
Add dialog components for Blade views

### DIFF
--- a/resources/views/components/dialog/close.blade.php
+++ b/resources/views/components/dialog/close.blade.php
@@ -1,0 +1,3 @@
+<span x-on:click="dialogOpen = false">
+    {{ $slot }}
+</span>

--- a/resources/views/components/dialog/footer.blade.php
+++ b/resources/views/components/dialog/footer.blade.php
@@ -1,0 +1,5 @@
+<div class="p-4 py-4 px-4 -mx-8 -mb-8 mt-8 bg-slate-100">
+    <div class="flex justify-end gap-4">
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/components/dialog/index.blade.php
+++ b/resources/views/components/dialog/index.blade.php
@@ -1,0 +1,8 @@
+<div
+    x-data="{ dialogOpen: false }"
+    x-modelable="dialogOpen"
+    {{ $attributes }}
+    tabindex="-1"
+>
+    {{ $slot }}
+</div>

--- a/resources/views/components/dialog/open.blade.php
+++ b/resources/views/components/dialog/open.blade.php
@@ -1,0 +1,3 @@
+<span x-on:click="dialogOpen = true" tabindex="-1">
+    {{ $slot }}
+</span>

--- a/resources/views/components/dialog/panel.blade.php
+++ b/resources/views/components/dialog/panel.blade.php
@@ -1,0 +1,52 @@
+<template x-teleport="body">
+    <div
+        x-dialog
+        x-model="dialogOpen"
+        style="display: none"
+        class="fixed inset-0 overflow-y-auto z-10 text-left pt-[30%] sm:pt-0"
+    >
+        <!-- Overlay -->
+        <div x-dialog:overlay x-transition:enter.opacity class="fixed inset-0 bg-black/25"></div>
+
+        <!-- Panel -->
+        <div class="relative min-h-full flex justify-center items-end sm:items-center p-0 sm:p-4">
+            <div
+                x-dialog:panel
+                x-transition.in
+                class="relative max-w-xl w-full bg-white rounded-t-xl sm:rounded-b-xl shadow-lg overflow-hidden"
+            >
+                <!-- Mobile: Top "grab" handle... -->
+                <div
+                    class="sm:hidden absolute top-[-10px] left-0 right-0 h-[50px]"
+                    x-data="{ startY: 0, currentY: 0, moving: false, get distance() { return this.moving ? Math.max(0, this.currentY - this.startY): 0 } }"
+                    x-on:touchstart="moving = true; startY = currentY = $event.touches[0].clientY"
+                    x-on:touchmove="currentY = $event.touches[0].clientY"
+                    x-on:touchend="if (distance > 100) $dialog.close(); moving = false;"
+                    x-effect="$el.parentElement.style.transform = 'translateY('+distance+'px)'"
+                >
+                    <div class="flex justify-center pt-[12px]">
+                        <div class="bg-gray-400 rounded-full w-[10%] h-[5px]"></div>
+                    </div>
+                </div>
+
+                <!-- Close Button -->
+                <div class="absolute top-0 right-0 pt-4 pr-4">
+                    <button type="button" x-on:click="$dialog.close()"
+                            class="bg-gray-50 rounded-lg p-2 text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2">
+                        <span class="sr-only">Close modal</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd"
+                                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                                  clip-rule="evenodd"/>
+                        </svg>
+                    </button>
+                </div>
+
+                <!-- Panel -->
+                <div class="p-8">
+                    {{ $slot }}
+                </div>
+            </div>
+        </div>
+    </div>
+</template>


### PR DESCRIPTION
Created five separate Blade Components for a dialog box implementation in Laravel. These include dialog panel, open button, close button, footer, and base index. Allows easy and flexible re-use in various views. Improved dialog box features such as an overlay and specific elements positioning.