### PR TITLE
Update local storage handling on login

### DIFF
--- a/app/Livewire/Auth/Login.php
+++ b/app/Livewire/Auth/Login.php
@@ -98,7 +98,7 @@ class Login extends Component
 
     private function handleSuccessfulLogin(): void
     {
-        $this->dispatch('clearLocalStorage');
+        $this->dispatch('removeLastAction');
 
         // redirect to previous url or to the dashboard
         if ($this->redirectUrl) {

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -62,8 +62,8 @@
     </div>
 
     <script>
-        window.addEventListener('clearLocalStorage', function () {
-            localStorage.clear();
+        window.addEventListener('removeLastAction', function () {
+            localStorage.removeItem('lastAction');
         })
     </script>
 </div>


### PR DESCRIPTION
Changed the event listener for handling local storage operations after successful login. Instead of clearing all local storage, only the 'lastAction' item is now being removed. This ensures other necessary data in local storage is not unnecessarily deleted.