### PR TITLE
Fix composer update command in GitHub workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 
       - name: Prepare Laravel Application
         run: |


### PR DESCRIPTION
Updated the composer update command in the GitHub workflows file, removing the no-suggest option. This option was deprecated as of Composer 2.0, hence its removal maintains compatibility with the latest versions of the tool.