### PR TITLE
Update Laratrust tables and configurations

### DIFF
--- a/config/laratrust.php
+++ b/config/laratrust.php
@@ -121,7 +121,7 @@ return [
         /**
          * Will be used only if the teams functionality is enabled.
          */
-        'team' => \App\Models\Team::class,
+        'team' => \App\Models\Location::class,
     ],
 
     /*
@@ -141,7 +141,7 @@ return [
         /**
          * Will be used only if the teams functionality is enabled.
          */
-        'teams' => 'teams',
+        'teams' => 'locations',
 
         'role_user' => 'role_user',
 
@@ -177,7 +177,7 @@ return [
         /**
          * Role foreign key on Laratrust's role_user and permission_user tables.
          */
-        'team' => 'team_id',
+        'team' => 'location_id',
     ],
 
     /*

--- a/database/migrations/2024_04_07_200420_laratrust_setup_tables.php
+++ b/database/migrations/2024_04_07_200420_laratrust_setup_tables.php
@@ -30,27 +30,27 @@ return new class extends Migration
         });
 
         // Create table for storing teams
-        Schema::create('teams', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('name')->unique();
-            $table->string('display_name')->nullable();
-            $table->string('description')->nullable();
-            $table->timestamps();
-        });
+//        Schema::create('teams', function (Blueprint $table) {
+//            $table->bigIncrements('id');
+//            $table->string('name')->unique();
+//            $table->string('display_name')->nullable();
+//            $table->string('description')->nullable();
+//            $table->timestamps();
+//        });
 
         // Create table for associating roles to users and teams (Many To Many Polymorphic)
         Schema::create('role_user', function (Blueprint $table) {
             $table->unsignedBigInteger('role_id');
             $table->unsignedBigInteger('user_id');
             $table->string('user_type');
-            $table->unsignedBigInteger('team_id')->nullable();
+            $table->unsignedBigInteger('location_id')->nullable();
 
             $table->foreign('role_id')->references('id')->on('roles')
                 ->onUpdate('cascade')->onDelete('cascade');
-            $table->foreign('team_id')->references('id')->on('teams')
+            $table->foreign('location_id')->references('id')->on('locations')
                 ->onUpdate('cascade')->onDelete('cascade');
 
-            $table->unique(['user_id', 'role_id', 'user_type', 'team_id']);
+            $table->unique(['user_id', 'role_id', 'user_type', 'location_id']);
         });
 
         // Create table for associating permissions to users (Many To Many Polymorphic)
@@ -58,14 +58,14 @@ return new class extends Migration
             $table->unsignedBigInteger('permission_id');
             $table->unsignedBigInteger('user_id');
             $table->string('user_type');
-            $table->unsignedBigInteger('team_id')->nullable();
+            $table->unsignedBigInteger('location_id')->nullable();
 
             $table->foreign('permission_id')->references('id')->on('permissions')
                 ->onUpdate('cascade')->onDelete('cascade');
-            $table->foreign('team_id')->references('id')->on('teams')
+            $table->foreign('location_id')->references('id')->on('locations')
                 ->onUpdate('cascade')->onDelete('cascade');
 
-            $table->unique(['user_id', 'permission_id', 'user_type', 'team_id']);
+            $table->unique(['user_id', 'permission_id', 'user_type', 'location_id'], 'permission_user_id_permission_id_user_type_location_id_unique');
         });
 
         // Create table for associating permissions to roles (Many-to-Many)
@@ -92,6 +92,6 @@ return new class extends Migration
         Schema::dropIfExists('permissions');
         Schema::dropIfExists('role_user');
         Schema::dropIfExists('roles');
-        Schema::dropIfExists('teams');
+//        Schema::dropIfExists('teams');
     }
 };


### PR DESCRIPTION
This commit changes the use of 'teams' in Laratrust to 'locations' in the system. The migrations and configurations are updated replacing "team" with "location", to reflect the change in the system concept. Therefore, "team" instances in both the database migration and Laratrust configuration file have been replaced with "location".