### PR TITLE
Add UserPolicy and update 'work' permission

### DIFF
--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class UserPolicy
+{
+    use HandlesAuthorization;
+
+    public function work(User $user): bool
+    {
+        // If the user has global 'work-without-shift' permission, return true immediately.
+        if ($user->isAbleTo('work-without-shift')) {
+            return true;
+        }
+
+        // Check for 'work-without-shift' permission in each location and return true immediately if found.
+        foreach ($user->locations as $location) {
+            if ($user->isAbleTo('work-without-shift', $location)) {
+                return true;
+            }
+        }
+
+        // If the user does not have the 'work-without-shift' permission, check if they are on duty.
+        return $user->isOnDuty();
+    }
+
+    //    public function viewAny(User $user): bool
+    //    {
+    //
+    //    }
+    //
+    //    public function view(User $user, User $model): bool
+    //    {
+    //    }
+    //
+    //    public function create(User $user): bool
+    //    {
+    //    }
+    //
+    //    public function update(User $user, User $model): bool
+    //    {
+    //    }
+    //
+    //    public function delete(User $user, User $model): bool
+    //    {
+    //    }
+    //
+    //    public function restore(User $user, User $model): bool
+    //    {
+    //    }
+    //
+    //    public function forceDelete(User $user, User $model): bool
+    //    {
+    //    }
+}

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -39,8 +39,8 @@ class PermissionSeeder extends Seeder
         // end user block
 
         $this->createPermission(
-            'need-no-shift',
-            'Need no Shift',
+            'work-without-shift',
+            'Can work without shift',
             'Needs no shift to work'
         );
 

--- a/resources/views/components/nav.blade.php
+++ b/resources/views/components/nav.blade.php
@@ -26,7 +26,7 @@
             </button>
         </div>
         <div class="hidden lg:flex lg:gap-x-12">
-            @if(auth()->user()->isOnDuty()) {{-- don't show menu if not on duty --}}
+            @can('work', \App\Models\User::class)
                 <a href="#" class="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200">Product</a>
                 <a href="#" class="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200">Features</a>
                 <a href="#" class="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200">Marketplace</a>
@@ -55,7 +55,7 @@
                 </div>
             @elseif(auth()->user()->locations()->count())
                 <button type="button" @click="$dispatch('start-shift')" class="text-sm font-semibold leading-6 text-gray-900 dark:text-gray-200 uppercase">{{ __('Please start your shift or log out!') }}</button>
-            @endif
+            @endcan
         </div>
         <div class="hidden lg:flex lg:flex-1 lg:justify-end">
             <livewire:shift @shift-changed="$refresh" identifier="desktop"/>
@@ -117,7 +117,7 @@
             <div class="mt-6 flow-root">
                 <div class="-my-6 divide-y divide-gray-500/10">
                     <div class="space-y-2 py-6">
-                        @if(auth()->user()->isOnDuty()) {{-- don't show menu if not on duty --}}
+                        @can('work', \App\Models\User::class)
                             <a href="#"
                                class="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold leading-7 text-gray-900 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600">Product</a>
                             <a href="#"
@@ -150,7 +150,7 @@
                                @click="$dispatch('start-shift')"
                                class="-mx-3 block rounded-lg px-3 py-2 text-base font-semibold leading-7 text-gray-900 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600">{{ __('Please start your shift or log out!') }}
                             </button>
-                        @endif
+                        @endcan
                     </div>
                     <div class="border-t border-gray-200 pt-4 pb-3">
                         <div class="flex items-center px-4">


### PR DESCRIPTION
A new UserPolicy has been created to handle user permissions more efficiently, with the main focus being their ability to work. The 'need-no-shift' permission has been renamed to 'work-without-shift' for better clarity. The navigation blade was also updated to use the newly created policy. This change improves the permission logic and makes code maintenance easier.