### PR TITLE
Split 'fullname' into 'firstname' and 'lastname'

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,12 +28,13 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
-        $name = fake()->name;
+        $name = explode(' ', fake()->name);
 
         return [
             'personal-number' => fake()->numberBetween(100, 1000),
-            'username' => strtolower(str_replace(' ', '.', $name)),
-            'fullname' => $name,
+            'username' => strtolower($name[0] . '.' . $name[1]),
+            'lastname' => $name[1],
+            'firstname' => $name[0],
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'active' => $this->faker->boolean(),

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -19,7 +19,8 @@ return new class extends Migration
             $table->id();
             $table->string('personal-number');
             $table->string('username');
-            $table->string('fullname');
+            $table->string('lastname');
+            $table->string('firstname');
             $table->string('email')->unique()->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->boolean('active');


### PR DESCRIPTION
In the users table migration, the 'fullname' column has been split into two separate columns - 'firstname' and 'lastname'. This change allows for a more precise identification and sorting of user records.