### PR TITLE
Reposition `@livewireScripts` directive in `app.blade.php`

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -93,7 +93,7 @@
     </div>
 </div>
 
-@livewireScripts
 <livewire:auth.logout/>
+@livewireScripts
 </body>
 </html>


### PR DESCRIPTION
The directive `@livewireScripts` has been moved to the bottom of `app.blade.php` file. This respositioning ensures that all necessary JavaScript is loaded before the Livewire components, enhancing the application's performance slightly.