### PR TITLE
Refactor user shift and authorization states

### DIFF
--- a/app/Livewire/Journal.php
+++ b/app/Livewire/Journal.php
@@ -27,9 +27,10 @@ class Journal extends Component
         $this->setLocationData($this->actual_location);
     }
 
+
     public function render()
     {
-        $this->checkUserAuthorization();
+        $this->checkUserShift();
 
         $journals = JournalModel::where('location_id', $this->actual_location)
             ->with('category')
@@ -68,7 +69,7 @@ class Journal extends Component
             ? Location::all() : $this->user->locations;
     }
 
-    private function checkUserAuthorization(): void
+    private function checkUserShift(): void
     {
         if (! Gate::allows('work', $this->user)) {
             view('livewire.no-shift');

--- a/app/Models/Journal.php
+++ b/app/Models/Journal.php
@@ -5,7 +5,6 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Overtrue\LaravelVersionable\Versionable;
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -79,7 +79,7 @@ class User extends Authenticatable implements LaratrustUser
         return $this->belongsToMany(Location::class);
     }
 
-    public function createTimetrackerForUser($locationId, $event, $plan_time): void
+    public function createTimeTrackerForUser($locationId, $event, $plan_time): void
     {
         $this->timeTrackers()->create([
             'location_id' => $locationId,
@@ -97,9 +97,7 @@ class User extends Authenticatable implements LaratrustUser
 
     public function isOnDuty(): bool
     {
-        $user = $this->getUser();
-        // Check if the user is on shift
-        $shiftData = $this->getLocationIdIfOnShift($user);
+        $shiftData = $this->getShiftData();
         if ($shiftData['onDuty']) {
             return true;
         }
@@ -117,9 +115,7 @@ class User extends Authenticatable implements LaratrustUser
 
     public function getLocationId(): ?int
     {
-        $user = $this->getUser();
-        // get the LocationId, if the user is on shift
-        $shiftData = $this->getLocationIdIfOnShift($user);
+        $shiftData = $this->getShiftData();
         if ($shiftData['locationId']) {
             return $shiftData['locationId'];
         }
@@ -127,7 +123,20 @@ class User extends Authenticatable implements LaratrustUser
         return null;
     }
 
-    // Extracted method that retrieves the User entity
+    /**
+     * Retrieve the shift data
+     */
+    private function getShiftData(): array
+    {
+        // Get the logged-in user
+        $user = $this->getUser();
+        if ($user) {
+            return $this->getLocationIdIfOnShift($user);
+        }
+
+        return ['onDuty' => false, 'locationId' => null];
+    }
+
     private function getUser(): ?User
     {
         $user = Auth::user();


### PR DESCRIPTION
The commit updates how user's shift and authorization states are handled. A new property, canWork, is added to track authorization for work at the start and end of the shift. Also, the usage of checkUserAuthorization() is replaced with checkUserShift() for better consistency. Some methods in User model are renamed and updated to offer clearer functionality, such as fetching shift data and creating time tracker.