### PR TITLE
Update ban until date when adding incident

### DIFF
--- a/app/Livewire/AddIncident.php
+++ b/app/Livewire/AddIncident.php
@@ -273,7 +273,6 @@ class AddIncident extends Component
 
     private function processBanUntil($participantIndex, $newValue): void
     {
-        // prevent error if empty
         if (! $newValue) {
             $newValue = $this->incidentDate;
         }
@@ -286,7 +285,15 @@ class AddIncident extends Component
             $date->addYears(2000);
         }
 
-        // Now the checks, and if the date is less than 6 months in the future, recalculate it
+        // Fetch the participant's existing ban_until date if it exists and is later than the new date
+        if (isset($this->participants[$participantIndex]['id'])) {
+            $existingParticipant = Participant::find($this->participants[$participantIndex]['id']);
+            if (Carbon::parse($existingParticipant->ban_until)->greaterThan($date)) {
+                $date = Carbon::parse($existingParticipant->ban_until);
+            }
+        }
+
+        // If the date is less than 6 months in the future, recalculate it
         if ($date->lt($this->incidentDate) || $date->lt(Carbon::parse($this->incidentDate)->addMonths(6))) {
             $dob = Carbon::parse($this->participants[$participantIndex]['date_of_birth']);
             $age = $dob->diffInYears($this->incidentDate);

--- a/resources/views/livewire/add-incident.blade.php
+++ b/resources/views/livewire/add-incident.blade.php
@@ -230,7 +230,7 @@
                             </p>
 
                             @foreach($participants as $participant)
-                                <div wire:key="participant-{{ $loop->index }}" wire:loading.class="opacity-50" wire:target="participants.{{ $loop->index }}.date_of_birth"
+                                <div wire:key="participant-{{ $loop->index }}" wire:loading.class="opacity-50" wire:target="participants.{{ $loop->index }}.date_of_birth, participants.{{ $loop->index }}.ban_until"
                                      class="{{ $loop->iteration % 2 == 0 ? 'bg-gray-200 dark:bg-gray-800' : ''}}"
                                 >
                                     <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 sm:grid-cols-6">


### PR DESCRIPTION
Updated the Livewire AddIncident component to fix a bug where the 'ban until' date was not being validated against the existing 'ban until' date. Also added 'ban until' as a target in the wire loading attribute in the Laravel Blade file. This ensures that the 'ban until' date is updated correctly, and respects any existing 'ban until' date that the user might have, enhancing the incident adding functionality within the application.