### PR TITLE
Update text size in journal location dropdown

### DIFF
--- a/resources/views/livewire/journal.blade.php
+++ b/resources/views/livewire/journal.blade.php
@@ -6,7 +6,7 @@
                 <h1 class="text-base font-semibold leading-6 text-gray-900 dark:text-gray-200">
                     {{ t('Journal') }} -
                     <div class="inline-block">
-                        <select wire:model.live="actual_location" class="w-64 bg-white dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 py-2 pl-1 pr-10 text-sm text-gray-900 dark:text-white border-0 ring-0 rounded-md text-left">
+                        <select wire:model.live="actual_location" class="text-base w-64 bg-white dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 py-2 pl-1 pr-10 text-gray-900 dark:text-white border-0 ring-0 rounded-md text-left">
                             <option value="">{{ t('Select your location') }}</option>
                             @foreach($locations as $location)
                                 @canany(['viewRecentJournal', 'viewFullJournal'], $location)


### PR DESCRIPTION
Increased the text size of the location dropdown in the journal view from 'text-sm' to 'text-base'. This makes it easier for users to read the available options and select their location.