### PR TITLE
Update pestphp/pest version and remove phpunit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,10 @@
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.0",
-        "pestphp/pest": "^2.30",
+        "pestphp/pest": "^2.34",
         "pestphp/pest-plugin-faker": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.2",
         "pestphp/pest-plugin-livewire": "^2.1",
-        "phpunit/phpunit": "^10.5",
         "spatie/laravel-ignition": "^2.4"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96e2101cabd53bb0993a1ede99e683ee",
+    "content-hash": "e932ff17f669fc319d1c33456cc665ff",
     "packages": [
         {
             "name": "brick/math",


### PR DESCRIPTION
* **Dependency Update**
This PR updates the 'pestphp/pest' package used in our application. This package helps us in testing our codebase efficiently. The version upgrade from '^2.30' to '^2.34' implies that some new features, improvements, or bug fixes have been introduced in the updated version, helping increase the efficiency and reliability of our app's testing procedures.