### PR TITLE
Remove unused code from journal views

### DIFF
--- a/resources/views/livewire/journal-row.blade.php
+++ b/resources/views/livewire/journal-row.blade.php
@@ -42,15 +42,6 @@
                 </x-menu.button>
 
                 <x-menu.items>
-{{--                    <x-menu.close>--}}
-{{--                        <x-menu.item--}}
-{{--                            wire:click="edit({{ $journal->id }})"--}}
-{{--                        >--}}
-{{--                            {{ t('Edit') }}--}}
-{{--                        </x-menu.item>--}}
-{{--                    </x-menu.close>--}}
-
-
                     @can('update', $journal)
                         <livewire:incident-modal :$location_data :key="$journal->id" :$journal @added="$refresh" />
                     @endcan

--- a/resources/views/livewire/journal.blade.php
+++ b/resources/views/livewire/journal.blade.php
@@ -13,16 +13,6 @@
                         noMatchMessage="{{ t('Sorry, no location was found for your request.') }}"
                         itemIdKey="actual_location"
                     ></x-select-search>
-{{--                    <select wire:model.live="actual_location" class="text-base w-64 bg-white dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 py-2 pl-1 pr-10 text-gray-900 dark:text-white border-0 ring-0 rounded-md text-left">--}}
-{{--                        <option value="">{{ t('Select your location') }}</option>--}}
-{{--                        @foreach($locations as $location)--}}
-{{--                            @canany(['viewRecentJournal', 'viewFullJournal'], $location)--}}
-{{--                                <option value="{{ $location->id }}">--}}
-{{--                                    {{ $location->name }} - {{ $location->location }}--}}
-{{--                                </option>--}}
-{{--                            @endcanany--}}
-{{--                        @endforeach--}}
-{{--                    </select>--}}
                 </div>
             </div>
             <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">


### PR DESCRIPTION
The commit removes commented-out code that was not in use within the 'journal.blade.php' and 'journal-row.blade.php' files. This cleanup improves readability by eliminating flagged-out sections that have been deemed unnecessary or obsolete.